### PR TITLE
Feat/ast write

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+dist
+bin
+node_modules

--- a/bin/cli
+++ b/bin/cli
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../dist/cli.js').run()
+require('../dist/src/cli.js').run()

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@babel/preset-env": "^7.7.4",
     "@babel/preset-typescript": "^7.7.4",
     "@types/jest": "24.0.23",
+    "@types/lodash": "^4.14.149",
     "@types/shelljs": "^0.8.6",
     "@types/yargs": "^13.0.3",
     "@typescript-eslint/eslint-plugin": "^2.10.0",
@@ -74,6 +75,7 @@
     ]
   },
   "dependencies": {
+    "lodash": "^4.17.15",
     "shelljs": "^0.8.3",
     "yargs": "^15.0.2"
   }

--- a/src/generateResources.ts
+++ b/src/generateResources.ts
@@ -1,5 +1,7 @@
 import fs from 'fs'
-import * as ts from 'typescript'
+import ts from 'typescript'
+
+import { orderObjectKeys } from './orderObjectKeys'
 
 export const generateResources = (files: string[]) => {
   for (const filename of files) {
@@ -7,7 +9,6 @@ export const generateResources = (files: string[]) => {
 
     const ast = ts.createSourceFile(filename, source, ts.ScriptTarget.Latest, true)
 
-    // now we have the file as ast
-    console.log(source, ast)
+    orderObjectKeys(ast)
   }
 }

--- a/src/generateResources.ts
+++ b/src/generateResources.ts
@@ -9,6 +9,10 @@ export const generateResources = (files: string[]) => {
 
     const ast = ts.createSourceFile(filename, source, ts.ScriptTarget.Latest, true)
 
-    orderObjectKeys(ast)
+    const orderedAst = orderObjectKeys(ast)
+
+    const printer = ts.createPrinter()
+    const data = printer.printFile(orderedAst)
+    fs.writeFileSync(filename, data, { encoding: 'utf8' })
   }
 }

--- a/src/orderObjectKeys.ts
+++ b/src/orderObjectKeys.ts
@@ -14,14 +14,20 @@ export const orderObjectKeys = (ast: ts.SourceFile) => {
           const { properties } = declaration.initializer as ts.ObjectLiteralExpression
 
           const orderedProperties = orderProperties(properties)
-          console.log(orderedProperties)
+
+          declaration.initializer = ts.createObjectLiteral(orderedProperties, true)
         }
       }
+
+      statement.declarationList = ts.createVariableDeclarationList(declarations)
     }
   }
+
+  ast.statements = statements
+  return ast
 }
 
 export const orderProperties = (properties: ts.NodeArray<ts.ObjectLiteralElementLike>) => {
   // @ts-ignore
-  return sortBy(properties, [o => o.name?.escapedText]) as ts.NodeArray<ts.ObjectLiteralElementLike>
+  return sortBy(properties, [o => o.name?.escapedText])
 }

--- a/src/orderObjectKeys.ts
+++ b/src/orderObjectKeys.ts
@@ -1,0 +1,27 @@
+import ts from 'typescript'
+import sortBy from 'lodash/sortBy'
+
+export const orderObjectKeys = (ast: ts.SourceFile) => {
+  const { statements } = ast
+
+  for (const statement of statements) {
+    if (ts.isVariableStatement(statement)) {
+      const { declarationList } = statement
+      const { declarations } = declarationList
+
+      for (const declaration of declarations) {
+        if (ts.isVariableDeclaration(declaration) && ts.isObjectLiteralExpression(declaration.initializer as ts.Node)) {
+          const { properties } = declaration.initializer as ts.ObjectLiteralExpression
+
+          const orderedProperties = orderProperties(properties)
+          console.log(orderedProperties)
+        }
+      }
+    }
+  }
+}
+
+export const orderProperties = (properties: ts.NodeArray<ts.ObjectLiteralElementLike>) => {
+  // @ts-ignore
+  return sortBy(properties, [o => o.name?.escapedText]) as ts.NodeArray<ts.ObjectLiteralElementLike>
+}

--- a/test/fixtures/Simple.input.ts
+++ b/test/fixtures/Simple.input.ts
@@ -1,0 +1,5 @@
+export const simple = {
+  c: 'c_value',
+  a: 'a_value',
+  b: 'b_value',
+}

--- a/test/fixtures/Simple.output.ts
+++ b/test/fixtures/Simple.output.ts
@@ -1,0 +1,5 @@
+export const simple = {
+  a: 'a_value',
+  b: 'b_value',
+  c: 'c_value',
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "sourceMap": false /* Generates corresponding '.map' file. */,
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist" /* Redirect output structure to the directory. */,
-    "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
+    "rootDir": "./" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
@@ -63,5 +63,7 @@
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
     "resolveJsonModule": true
-  }
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "bin", "test"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -959,6 +959,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/lodash@^4.14.149":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"


### PR DESCRIPTION
## What was done?

We have the following file:
```ts
// Simple.input.ts

export const simple = {
  c: 'c_value',
  a: 'a_value',
  b: 'b_value',
}
```

If we run `sort-object --src ./test/fixtures/Simple.input.ts` we get the following result:

```ts
// Simple.input.ts

export var simple = {
    a: 'a_value',
    b: 'b_value',
    c: 'c_value'
};
``` 

## Problems

- ASTs are changing `const`’s over `var`’s (Check #13)
- Printed file doesn’t respect identation settings of original file (Check #14)